### PR TITLE
Add community skill documentation and guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jrusso1020 @heygen-com/product-infra

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 ## Checklist
 
 - [ ] The skill is self-contained and its directory name matches `SKILL.md`.
+- [ ] New or renamed skills are linked in the README's **Available skills** table.
 - [ ] I read every instruction and script in the submitted skill.
 - [ ] I disclosed all dependencies, network access, credentials, costs, and side effects.
 - [ ] No secrets, private data, private endpoints, generated output, or opaque executables are included.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## What
+
+<!-- What skill or behavior does this PR add or change? -->
+
+## Why it belongs here
+
+<!-- What focused use case does it serve, and why is it not part of the curated public skills? -->
+
+## Trust boundary
+
+<!-- List commands, file access, network destinations, credentials, paid operations, and externally visible side effects. Write "None" where applicable. -->
+
+## Verification
+
+<!-- Describe the fresh-session tests you ran and include non-sensitive evidence. -->
+
+## Checklist
+
+- [ ] The skill is self-contained and its directory name matches `SKILL.md`.
+- [ ] I read every instruction and script in the submitted skill.
+- [ ] I disclosed all dependencies, network access, credentials, costs, and side effects.
+- [ ] No secrets, private data, private endpoints, generated output, or opaque executables are included.
+- [ ] Destructive, paid, or externally visible actions require explicit user confirmation.
+- [ ] Dependencies are minimal, pinned where practical, and license-compatible.
+- [ ] I tested the normal path and a failure or cancellation path in a fresh agent session.
+- [ ] `bash .github/scripts/validate-skills.sh` passes locally.

--- a/.github/scripts/validate-skills.sh
+++ b/.github/scripts/validate-skills.sh
@@ -55,6 +55,10 @@ while IFS= read -r -d '' skill_dir; do
     fail "$skill_file must have a non-empty description"
   fi
 
+  if ! grep -Fq "(skills/$skill_name/)" README.md; then
+    fail "$skill_name must be linked in the README Available skills table"
+  fi
+
   while IFS= read -r large_file; do
     fail "files larger than 5 MiB are not allowed: ${large_file#./}"
   done < <(find "$skill_dir" -type f -size +5M -print)

--- a/.github/scripts/validate-skills.sh
+++ b/.github/scripts/validate-skills.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+validation_failed=0
+skill_count=0
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  validation_failed=1
+}
+
+while IFS= read -r symlink; do
+  fail "symlinks are not allowed: ${symlink#./}"
+done < <(find . -path ./.git -prune -o -type l -print)
+
+while IFS= read -r -d '' skill_dir; do
+  skill_name="${skill_dir#./}"
+  skill_file="$skill_dir/SKILL.md"
+  skill_count=$((skill_count + 1))
+
+  if [[ ! "$skill_name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    fail "skill directory must use lowercase kebab-case: $skill_name"
+  fi
+
+  if [[ ! -f "$skill_file" ]]; then
+    fail "$skill_name must contain SKILL.md"
+    continue
+  fi
+
+  if [[ "$(sed -n '1p' "$skill_file")" != "---" ]]; then
+    fail "$skill_file must begin with YAML frontmatter"
+  elif ! awk 'NR > 1 && NR <= 50 && $0 == "---" { found = 1; exit } END { exit(found ? 0 : 1) }' "$skill_file"; then
+    fail "$skill_file must close its YAML frontmatter within 50 lines"
+  fi
+
+  frontmatter_name="$({ sed -n '2,/^---$/p' "$skill_file" || true; } | sed -nE 's/^name:[[:space:]]*([a-z0-9]+(-[a-z0-9]+)*)[[:space:]]*$/\1/p' | head -n 1)"
+  if [[ "$frontmatter_name" != "$skill_name" ]]; then
+    fail "$skill_file name must be unquoted and exactly match '$skill_name'"
+  fi
+
+  if ! sed -n '2,/^---$/p' "$skill_file" | grep -Eq '^description:[[:space:]]*[^[:space:]].*$'; then
+    fail "$skill_file must have a non-empty description"
+  fi
+
+  while IFS= read -r large_file; do
+    fail "files larger than 5 MiB are not allowed: ${large_file#./}"
+  done < <(find "$skill_dir" -type f -size +5M -print)
+
+  while IFS= read -r opaque_file; do
+    fail "compiled or archived files are not allowed: ${opaque_file#./}"
+  done < <(
+    find "$skill_dir" -type f \( \
+      -iname '*.7z' -o -iname '*.a' -o -iname '*.class' -o \
+      -iname '*.dll' -o -iname '*.dylib' -o -iname '*.exe' -o \
+      -iname '*.gz' -o -iname '*.jar' -o -iname '*.o' -o \
+      -iname '*.pyc' -o -iname '*.so' -o -iname '*.tar' -o \
+      -iname '*.tgz' -o -iname '*.wasm' -o -iname '*.zip' \
+    \) -print
+  )
+
+  while IFS= read -r secret_file; do
+    fail "credential files are not allowed: ${secret_file#./}"
+  done < <(
+    find "$skill_dir" -type f \( \
+      -name '.env' -o -name 'id_dsa' -o -name 'id_ed25519' -o \
+      -name 'id_rsa' -o -iname '*.key' -o -iname '*.p12' -o \
+      -iname '*.pem' -o -iname '*.pfx' \
+    \) -print
+  )
+done < <(find . -mindepth 1 -maxdepth 1 -type d ! -name '.*' -print0)
+
+if (( skill_count == 0 )); then
+  printf 'No skills found yet; repository-level files are valid.\n'
+fi
+
+if (( validation_failed != 0 )); then
+  exit 1
+fi
+
+printf 'Validated %d skill(s).\n' "$skill_count"

--- a/.github/scripts/validate-skills.sh
+++ b/.github/scripts/validate-skills.sh
@@ -7,6 +7,7 @@ cd "$repo_root"
 
 validation_failed=0
 skill_count=0
+skills_root="./skills"
 
 fail() {
   printf 'ERROR: %s\n' "$*" >&2
@@ -17,8 +18,16 @@ while IFS= read -r symlink; do
   fail "symlinks are not allowed: ${symlink#./}"
 done < <(find . -path ./.git -prune -o -type l -print)
 
+if [[ ! -d "$skills_root" ]]; then
+  fail "repository must contain a skills/ directory"
+fi
+
+while IFS= read -r shared_file; do
+  fail "files directly under skills/ are not allowed: ${shared_file#./}"
+done < <(find "$skills_root" -mindepth 1 -maxdepth 1 -type f ! -name '.gitkeep' -print)
+
 while IFS= read -r -d '' skill_dir; do
-  skill_name="${skill_dir#./}"
+  skill_name="$(basename "$skill_dir")"
   skill_file="$skill_dir/SKILL.md"
   skill_count=$((skill_count + 1))
 
@@ -71,7 +80,7 @@ while IFS= read -r -d '' skill_dir; do
       -iname '*.pem' -o -iname '*.pfx' \
     \) -print
   )
-done < <(find . -mindepth 1 -maxdepth 1 -type d ! -name '.*' -print0)
+done < <(find "$skills_root" -mindepth 1 -maxdepth 1 -type d ! -name '.*' -print0)
 
 if (( skill_count == 0 )); then
   printf 'No skills found yet; repository-level files are valid.\n'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,29 @@
+name: Validate community skills
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Structure and safety
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Validate skill structure
+        run: bash .github/scripts/validate-skills.sh
+
+      - name: Scan changed commits for secrets
+        uses: trufflesecurity/trufflehog@20652fbbdefffcdaa493a5bf57ab2ac6b1db715b # v3.97.1
+        with:
+          version: 3.97.1
+          extra_args: --results=verified,unknown

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Secrets and local environment
+.env
+.env.*
+!.env.example
+!.env.*.example
+.npmrc
+.pypirc
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Operating systems and editors
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Logs and temporary files
+*.log
+*.tmp
+.cache/
+.tmp/
+tmp/
+temp/
+
+# JavaScript and TypeScript
+node_modules/
+.pnpm-store/
+.yarn/
+.next/
+.turbo/
+coverage/
+.nyc_output/
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+
+# Common build and generated output
+build/
+dist/
+out/
+output/
+outputs/
+renders/
+target/
+*.class

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,20 +8,22 @@ boundary.
 ## Before you start
 
 - Search the repository for an existing skill that covers the same workflow.
-- Keep the skill self-contained. Do not add shared runtime code at the root.
+- Keep the skill self-contained. Do not add shared runtime code under `skills/`
+  or at the repository root.
 - Confirm that you have the right to redistribute every dependency and asset.
 - Do not submit credentials, customer data, private URLs, or generated output.
 
 ## Skill structure
 
-Create one lowercase kebab-case directory at the repository root:
+Create one lowercase kebab-case directory under `skills/`:
 
 ```text
-my-specific-workflow/
-├── SKILL.md
-├── scripts/       # optional
-├── references/    # optional
-└── assets/        # optional
+skills/
+└── my-specific-workflow/
+    ├── SKILL.md
+    ├── scripts/       # optional
+    ├── references/    # optional
+    └── assets/        # optional
 ```
 
 `SKILL.md` must begin with YAML frontmatter whose `name` exactly matches the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing
+
+This repository collects focused HyperFrames skills that are useful to share
+but are too specialized for the curated public skill set. Contributions should
+be small enough for a reviewer to understand the complete behavior and trust
+boundary.
+
+## Before you start
+
+- Search the repository for an existing skill that covers the same workflow.
+- Keep the skill self-contained. Do not add shared runtime code at the root.
+- Confirm that you have the right to redistribute every dependency and asset.
+- Do not submit credentials, customer data, private URLs, or generated output.
+
+## Skill structure
+
+Create one lowercase kebab-case directory at the repository root:
+
+```text
+my-specific-workflow/
+├── SKILL.md
+├── scripts/       # optional
+├── references/    # optional
+└── assets/        # optional
+```
+
+`SKILL.md` must begin with YAML frontmatter whose `name` exactly matches the
+directory:
+
+```yaml
+---
+name: my-specific-workflow
+description: Use when an agent needs to do a specific HyperFrames workflow.
+---
+```
+
+The instructions should explain:
+
+1. when to use and when not to use the skill;
+2. required inputs, tools, dependencies, and credentials;
+3. the workflow and its expected outputs;
+4. network calls, paid operations, file changes, and other side effects;
+5. how the agent and reviewer can verify success.
+
+Use relative links for files owned by the skill. An agent reading only that
+skill directory should have everything needed to follow it.
+
+## Safety and quality requirements
+
+Pull requests will not be merged if they contain:
+
+- secrets, tokens, personal data, private endpoints, or real credentials;
+- obfuscated, minified, vendored, generated, or unexplained executable code;
+- compiled executables, dynamic libraries, bytecode, or archives that hide
+  reviewable source;
+- symlinks, install-time execution, or undeclared downloads;
+- silent telemetry, tracking, or data exfiltration;
+- destructive actions without a safe default and explicit user confirmation;
+- paid or externally visible actions without explicit user confirmation;
+- broad filesystem, shell, or network access that the workflow does not need;
+- unpinned dependencies where an upstream change could alter behavior;
+- instructions that weaken authentication, authorization, sandboxing, or other
+  security controls.
+
+Scripts must be readable source, minimal, and directly necessary for the skill.
+Prefer standard tools over adding dependencies. If a network service is needed,
+name the service, the data sent to it, the credentials it uses, and whether it
+can incur cost.
+
+## Test locally
+
+Run the repository validator:
+
+```bash
+bash .github/scripts/validate-skills.sh
+```
+
+Then test the skill with a fresh agent session that has access only to the skill
+and the dependencies documented in it. Exercise the normal path and at least one
+failure or cancellation path. Do not use production credentials or sensitive
+data in test fixtures or evidence.
+
+## Open a pull request
+
+Create a new branch from `master` and keep the pull request scoped to one skill
+or one coherent fix. In the pull request:
+
+- explain the use case and why it belongs in the community collection;
+- enumerate commands, network destinations, credentials, costs, and side
+  effects;
+- describe the tests you ran and include non-sensitive evidence;
+- disclose dependencies and licenses;
+- call out any residual risk a user should understand.
+
+All required checks must pass and a code owner must approve the exact head
+commit. Resolve review threads before merge. Do not push directly to `master`.
+
+Contributions are licensed under the repository's Apache 2.0 license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ The instructions should explain:
 Use relative links for files owned by the skill. An agent reading only that
 skill directory should have everything needed to follow it.
 
+Add new and renamed skills to the **Available skills** table in `README.md`.
+Link the skill name as `skills/<skill-name>/` and describe the concrete use case
+in one sentence. Remove the empty-catalog message when adding the first skill.
+
 ## Safety and quality requirements
 
 Pull requests will not be merged if they contain:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,99 @@
+# HyperFrames Community Skills
+
+A community-maintained collection of focused, one-off skills for
+[HyperFrames](https://github.com/heygen-com/hyperframes).
+
+This repository is for useful skills built around a specific workflow, tool, or
+use case that do not belong in HyperFrames' curated public skill set. Each
+top-level directory is an independent skill and can be installed on its own.
+
+> [!CAUTION]
+> Community skills are not part of the curated HyperFrames distribution. A
+> skill can instruct an agent to run commands, read files, call network services,
+> or spend money. Review its `SKILL.md`, scripts, dependencies, and requested
+> permissions before using it. Repository review and automated checks reduce
+> risk, but they are not a security guarantee.
+
+## Install a skill
+
+Replace `<skill-name>` with the name of a top-level skill directory.
+
+### GitHub CLI
+
+With GitHub CLI 2.90 or later:
+
+```bash
+gh auth login
+gh skill install heygen-com/hyperframes-community-skills <skill-name>
+```
+
+`gh auth login` is only required when you are not already authenticated or the
+repository requires access.
+
+### Sparse checkout
+
+To download one skill without installing it automatically:
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse \
+  git@github.com:heygen-com/hyperframes-community-skills.git
+cd hyperframes-community-skills
+git sparse-checkout set <skill-name>
+```
+
+The skill will be at `hyperframes-community-skills/<skill-name>`. Copy or link
+that directory into the skills directory used by your agent.
+
+## Download all skills
+
+Clone the repository into a directory your agent scans for skills, or clone it
+elsewhere and copy the skills you want:
+
+```bash
+git clone --depth 1 \
+  git@github.com:heygen-com/hyperframes-community-skills.git
+```
+
+To update a clone later, run `git pull --ff-only` inside it. Review incoming
+changes before making the updated skills available to an agent.
+
+## Repository layout
+
+Every skill is self-contained:
+
+```text
+<skill-name>/
+├── SKILL.md          # Required instructions and metadata
+├── scripts/          # Optional readable source code
+├── references/       # Optional supporting documentation
+└── assets/           # Optional small, redistributable assets
+```
+
+Skill directory names use lowercase kebab-case and must match the `name` field
+in `SKILL.md`. There is no root skill and no shared runtime dependency between
+skills.
+
+## Contribute
+
+Contributions are welcome when a skill is:
+
+- useful for a concrete HyperFrames workflow;
+- narrow enough to understand and review independently;
+- self-contained, documented, and tested;
+- explicit about network access, credentials, paid services, and side effects;
+- made from readable source without bundled secrets or opaque executables.
+
+All changes go through a pull request, code-owner review, structural validation,
+and secret scanning. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full quality
+and safety bar.
+
+## Curated vs. community skills
+
+Use the curated HyperFrames skills for common, supported workflows. Use this
+repository for specialized or experimental workflows whose smaller audience
+does not justify inclusion in the public set. Inclusion here does not imply that
+a skill will graduate into the curated distribution.
+
+## License
+
+Apache 2.0. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A community-maintained collection of focused, one-off skills for
 
 This repository is for useful skills built around a specific workflow, tool, or
 use case that do not belong in HyperFrames' curated public skill set. Each
-top-level directory is an independent skill and can be installed on its own.
+directory under `skills/` is independent and can be installed on its own.
 
 > [!CAUTION]
 > Community skills are not part of the curated HyperFrames distribution. A
@@ -14,23 +14,39 @@ top-level directory is an independent skill and can be installed on its own.
 > permissions before using it. Repository review and automated checks reduce
 > risk, but they are not a security guarantee.
 
-## Install a skill
+## Install skills
 
-Replace `<skill-name>` with the name of a top-level skill directory.
-
-### GitHub CLI
-
-With GitHub CLI 2.90 or later:
+This repository uses the same
+[`skills`](https://github.com/vercel-labs/skills) installer as HyperFrames.
+List the available skills without installing anything:
 
 ```bash
-gh auth login
-gh skill install heygen-com/hyperframes-community-skills <skill-name>
+npx skills add heygen-com/hyperframes-community-skills --list
 ```
 
-`gh auth login` is only required when you are not already authenticated or the
-repository requires access.
+### Install one skill
 
-### Sparse checkout
+Replace `<skill-name>` with the name of a directory under `skills/`:
+
+```bash
+npx skills add heygen-com/hyperframes-community-skills --skill <skill-name>
+```
+
+### Install all skills
+
+```bash
+npx skills add heygen-com/hyperframes-community-skills --all
+```
+
+By default, `skills add` installs into the current project and prompts for the
+agents to target. Use its `--global`, `--agent`, and `--yes` options when you
+need a global or non-interactive install.
+
+For a private repository, the installer uses existing Git, GitHub CLI, or SSH
+authentication. Run `gh auth login` first if your machine does not already have
+access configured.
+
+## Download without installing
 
 To download one skill without installing it automatically:
 
@@ -38,16 +54,12 @@ To download one skill without installing it automatically:
 git clone --depth 1 --filter=blob:none --sparse \
   git@github.com:heygen-com/hyperframes-community-skills.git
 cd hyperframes-community-skills
-git sparse-checkout set <skill-name>
+git sparse-checkout set skills/<skill-name>
 ```
 
-The skill will be at `hyperframes-community-skills/<skill-name>`. Copy or link
-that directory into the skills directory used by your agent.
+The skill will be at `hyperframes-community-skills/skills/<skill-name>`.
 
-## Download all skills
-
-Clone the repository into a directory your agent scans for skills, or clone it
-elsewhere and copy the skills you want:
+To download the complete collection:
 
 ```bash
 git clone --depth 1 \
@@ -55,23 +67,25 @@ git clone --depth 1 \
 ```
 
 To update a clone later, run `git pull --ff-only` inside it. Review incoming
-changes before making the updated skills available to an agent.
+changes before installing or copying the updated skills.
 
 ## Repository layout
 
 Every skill is self-contained:
 
 ```text
-<skill-name>/
-├── SKILL.md          # Required instructions and metadata
-├── scripts/          # Optional readable source code
-├── references/       # Optional supporting documentation
-└── assets/           # Optional small, redistributable assets
+skills/
+└── <skill-name>/
+    ├── SKILL.md          # Required instructions and metadata
+    ├── scripts/          # Optional readable source code
+    ├── references/       # Optional supporting documentation
+    └── assets/           # Optional small, redistributable assets
 ```
 
 Skill directory names use lowercase kebab-case and must match the `name` field
-in `SKILL.md`. There is no root skill and no shared runtime dependency between
-skills.
+in `SKILL.md`. This native `skills/` layout lets the installer discover the
+collection without a broad `--full-depth` scan. There is no root skill and no
+shared runtime dependency between skills.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ directory under `skills/` is independent and can be installed on its own.
 > permissions before using it. Repository review and automated checks reduce
 > risk, but they are not a security guarantee.
 
+## Available skills
+
+No community skills have been added yet. New skills will be listed here so the
+collection remains browseable without opening the `skills/` directory first.
+
+| Skill | What it does |
+| --- | --- |
+
 ## Install skills
 
 This repository uses the same


### PR DESCRIPTION
## What

Establishes the repository as a collection of focused, one-off HyperFrames community skills.

- explains the repository's scope and trust model
- documents `npx skills add` for listing, installing one skill, or installing all skills
- defines the native `skills/<name>/SKILL.md` layout and contribution requirements
- ignores common secrets, dependencies, caches, and generated output without excluding valid skill assets
- adds code owners, a security-focused PR checklist, structural validation, and pinned secret-scanning CI

## Why

Community skills can contain executable instructions and scripts. Contributors need a clear place for specialized workflows, while users and reviewers need explicit trust boundaries and enforceable checks before those skills are used or merged.

## Verification

- `bash .github/scripts/validate-skills.sh`
- valid fixture accepted
- invalid fixture rejected for bad naming, mismatched metadata, and credential files
- current `skills` CLI v1.5.23 discovered a valid local fixture with `--list`
- `git diff --check`
- action versions pinned to immutable commits (`actions/checkout` v7.0.1 and TruffleHog v3.97.1)

## Repository setting required after merge

Add a `master` ruleset that requires pull requests, code-owner approval, resolved conversations, and the `Structure and safety` check. The existing org ruleset only enforces signed commits, so repository files alone cannot prevent direct-push bypasses.
