### PR TITLE
Prepare community skills for public contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a reproducible problem with a community skill or this repository
+labels: ["bug"]
+body:
+  - type: input
+    id: skill
+    attributes:
+      label: Affected skill
+      description: Enter the skill directory name, or "repository" for shared infrastructure.
+      placeholder: p5-paint-animation
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the actual and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include minimal inputs and exact commands, with secrets and private data removed.
+      placeholder: |
+        1. Install the skill with ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your OS, agent, runtime versions, and relevant dependency versions.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Non-sensitive evidence
+      description: Paste logs or screenshots only after removing secrets, private URLs, and personal data.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I removed credentials, private data, and private endpoints from this report.
+          required: true
+        - label: This is not an undisclosed security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/heygen-com/hyperframes-community-skills/security/advisories/new
+    about: Report security issues privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/skill-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/skill-proposal.yml
@@ -1,0 +1,41 @@
+name: Skill proposal
+description: Propose a focused HyperFrames community skill
+labels: ["enhancement"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Proposed skill name
+      description: Use a lowercase kebab-case name.
+      placeholder: my-specific-workflow
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Who needs this skill, and what concrete workflow would it complete?
+    validations:
+      required: true
+  - type: textarea
+    id: existing
+    attributes:
+      label: Why existing skills are not enough
+      description: Link any related curated or community skills and explain the gap.
+    validations:
+      required: true
+  - type: textarea
+    id: trust-boundary
+    attributes:
+      label: Trust boundary
+      description: List commands, files, dependencies, network services, credentials, costs, and side effects.
+      placeholder: Write "None" for categories that do not apply.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification plan
+      description: How will contributors and reviewers test normal and failure paths safely?
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /skills/p5-paint-animation/scripts
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in this community a harassment-free experience
+for everyone, regardless of age, body size, disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socioeconomic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our standards
+
+Positive behavior includes using welcoming language, respecting differing
+viewpoints, accepting constructive feedback, focusing on what is best for the
+community, and showing empathy toward others.
+
+Unacceptable behavior includes sexualized language or attention, trolling,
+insults, personal or political attacks, public or private harassment,
+publishing another person's private information without permission, and other
+conduct that would be inappropriate in a professional setting.
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject contributions and interactions
+that violate these standards. Report abusive, harassing, or otherwise
+unacceptable behavior to the maintainers through a
+[GitHub issue](https://github.com/heygen-com/hyperframes-community-skills/issues).
+If a report contains private information, send it to `security@heygen.com`
+instead of posting it publicly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ boundary.
 ## Before you start
 
 - Search the repository for an existing skill that covers the same workflow.
+- Search existing issues, and open a skill proposal before investing in a
+  substantial new skill.
 - Keep the skill self-contained. Do not add shared runtime code under `skills/`
   or at the repository root.
 - Confirm that you have the right to redistribute every dependency and asset.
@@ -73,6 +75,10 @@ Prefer standard tools over adding dependencies. If a network service is needed,
 name the service, the data sent to it, the credentials it uses, and whether it
 can incur cost.
 
+AI-assisted contributions are welcome, but the submitter remains responsible
+for every instruction and script. Do not submit behavior you have not read,
+understood, and tested.
+
 ## Test locally
 
 Run the repository validator:
@@ -88,8 +94,9 @@ data in test fixtures or evidence.
 
 ## Open a pull request
 
-Create a new branch from `master` and keep the pull request scoped to one skill
-or one coherent fix. In the pull request:
+Fork the repository, create a new branch from `master`, and open a pull request
+against this repository. Keep it scoped to one skill or one coherent fix. In
+the pull request:
 
 - explain the use case and why it belongs in the community collection;
 - enumerate commands, network destinations, credentials, costs, and side
@@ -101,4 +108,5 @@ or one coherent fix. In the pull request:
 All required checks must pass and a code owner must approve the exact head
 commit. Resolve review threads before merge. Do not push directly to `master`.
 
+By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 Contributions are licensed under the repository's Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HyperFrames Community Skills
 
+[![Validate community skills](https://github.com/heygen-com/hyperframes-community-skills/actions/workflows/validate.yml/badge.svg)](https://github.com/heygen-com/hyperframes-community-skills/actions/workflows/validate.yml)
+
 A community-maintained collection of focused, one-off skills for
 [HyperFrames](https://github.com/heygen-com/hyperframes).
 
@@ -48,9 +50,8 @@ By default, `skills add` installs into the current project and prompts for the
 agents to target. Use its `--global`, `--agent`, and `--yes` options when you
 need a global or non-interactive install.
 
-For a private repository, the installer uses existing Git, GitHub CLI, or SSH
-authentication. Run `gh auth login` first if your machine does not already have
-access configured.
+This repository is public, so installation does not require GitHub
+authentication.
 
 ## Download without installing
 
@@ -58,7 +59,7 @@ To download one skill without installing it automatically:
 
 ```bash
 git clone --depth 1 --filter=blob:none --sparse \
-  git@github.com:heygen-com/hyperframes-community-skills.git
+  https://github.com/heygen-com/hyperframes-community-skills.git
 cd hyperframes-community-skills
 git sparse-checkout set skills/<skill-name>
 ```
@@ -69,7 +70,7 @@ To download the complete collection:
 
 ```bash
 git clone --depth 1 \
-  git@github.com:heygen-com/hyperframes-community-skills.git
+  https://github.com/heygen-com/hyperframes-community-skills.git
 ```
 
 To update a clone later, run `git pull --ff-only` inside it. Review incoming
@@ -106,6 +107,11 @@ Contributions are welcome when a skill is:
 All changes go through a pull request, code-owner review, structural validation,
 and secret scanning. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full quality
 and safety bar.
+
+Use [GitHub Issues](https://github.com/heygen-com/hyperframes-community-skills/issues)
+for bug reports and skill proposals. Report security problems privately as
+described in [SECURITY.md](SECURITY.md), and follow our
+[Code of Conduct](CODE_OF_CONDUCT.md) when participating.
 
 ## Curated vs. community skills
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Report a vulnerability
+
+Report vulnerabilities through
+[GitHub's private vulnerability reporting](https://github.com/heygen-com/hyperframes-community-skills/security/advisories/new).
+Do not open a public issue or pull request for an undisclosed vulnerability.
+
+Include the affected skill or repository component, impact, reproduction steps,
+and a suggested mitigation when possible. Never include live credentials,
+customer data, or other sensitive material.
+
+This policy covers skill instructions and scripts, dependency or supply-chain
+risks, repository automation, and ways a skill could access or modify more than
+it discloses. Vulnerabilities in the HeyGen or HyperFrames products themselves
+should be reported to `security@heygen.com`.
+
+Only the current default branch is supported. Maintainers will coordinate
+disclosure after a fix or mitigation is available.


### PR DESCRIPTION
## What

- replace private-repository install guidance with public HTTPS instructions
- add a security policy and private vulnerability-reporting route
- add a Contributor Covenant-based code of conduct
- add structured bug-report and skill-proposal issue forms
- add weekly dependency updates for the first skill's npm dependencies
- document fork-based and AI-assisted contribution expectations

## Live repository settings applied

- added a public description and discovery topics
- disabled unused wiki and projects surfaces
- enabled secret scanning, push protection, Dependabot security updates, and private vulnerability reporting
- restricted Actions to read-only workflow tokens, GitHub-owned actions, and the pinned TruffleHog action
- made squash the only merge method and enabled automatic branch cleanup
- protected the default branch with no bypass, one fresh CODEOWNER approval, resolved conversations, signed commits, an up-to-date branch, and the required `Structure and safety` check

## Verification

- repository validator passes with 1 skill
- all GitHub YAML parses successfully
- staged diff passes `git diff --check`
- live settings were read back through the GitHub API

This PR is expected to require an independent CODEOWNER approval under the new rules.
